### PR TITLE
Identify Non-User Downloading

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -97,7 +97,14 @@ class Listener {
 		} else if ($this->request->isUserAgent([IRequest::USER_AGENT_CLIENT_ANDROID, IRequest::USER_AGENT_CLIENT_IOS])) {
 			$client = 'mobile';
 		}
-		$subjectParams = [[$fileId => $filePath], $this->currentUser->getUserIdentifier(), $client];
+		
+        	// Check if Current User is Guest
+        	if ($this->currentUser->getUserIdentifier() === '') {
+          		$requestor = 'Anonymous ' . $_SERVER['REMOTE_ADDR'];
+        	} else {
+          		$requestor = $this->currentUser->getUserIdentifier();
+        	}
+		$subjectParams = [[$fileId => $filePath], $requestor, $client];
 
 		if ($isDir) {
 			$subject = Provider::SUBJECT_SHARED_FOLDER_DOWNLOADED;


### PR DESCRIPTION
When a user not registered with a site is shared a link, the download of non registered users should be identified in the activity history in an identifiable way.  Anonymous users should have their IP's logged in history so that administrators can determine if the content is being downloaded by the originally intended party or if the information was forward beyond the original intention.  It also provides a method to get an idea which users have downloaded the file (intended) and when.