### PR TITLE
Improvement of some wordings (clearer and more consistent)

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -120,11 +120,11 @@ class Provider implements IProvider {
 		$params = $event->getSubjectParameters();
 
 		if ($params[2] === 'desktop') {
-			$subject = $this->l->t('Downloaded by {actor} (via desktop)');
+			$subject = $this->l->t('Downloaded by {actor} (via the desktop client)');
 		} elseif ($params[2] === 'mobile') {
-			$subject = $this->l->t('Downloaded by {actor} (via app)');
+			$subject = $this->l->t('Downloaded by {actor} (via the mobile app)');
 		} else {
-			$subject = $this->l->t('Downloaded by {actor} (via browser)');
+			$subject = $this->l->t('Downloaded by {actor} (via the browser)');
 		}
 
 		$this->setSubjects($event, $subject, $parsedParameters);

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -51,7 +51,7 @@ class Setting implements ISetting {
 	 * @since 11.0.0
 	 */
 	public function getName(): string {
-		return $this->l->t('A local shared file or folder was <strong>downloaded</strong>');
+		return $this->l->t('A locally shared file or folder was <strong>downloaded</strong>');
 	}
 
 	/**


### PR DESCRIPTION
Check commits : 

Settings : Because "local" is not appropriate. The goal of the app is to generate download notification for files that are shared locally = shared with local users or groups (not external shares).

Provider : Because wordings had a lack of consistency width existing others.