### PR TITLE
upgrade app to be compatible with Nextcloud 28 (issue #159)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/files_downloadactivity/master/docs/screenshot.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="24" max-version="26" />
+		<nextcloud min-version="26" max-version="28" />
 	</dependencies>
 
 	<activity>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/files_downloadactivity/master/docs/screenshot.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="26" max-version="28" />
+		<nextcloud min-version="27" max-version="30" />
 	</dependencies>
 
 	<activity>

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
 	"config": {
 		"classmap-authoritative": true,
 		"optimize-autoloader": true,
+		"sort-packages": true,
 		"platform": {
-			"php": "7.4"
-		},
-		"sort-packages": true
+			"php": "8.1"
+		}
 	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,10 +28,10 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\Files\File;
-use OCP\Util;
-use OCP\Preview\BeforePreviewFetchedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\File;
+use OCP\Preview\BeforePreviewFetchedEvent;
+use OCP\Util;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'files_downloadactivity';
@@ -46,9 +46,9 @@ class Application extends App implements IBootstrap {
 	public function boot(IBootContext $context): void {
 		Util::connectHook('OC_Filesystem', 'read', $this, 'listenReadFile');
 
-		$eventDispatcher = $this->getContainer()->query(IEventDispatcher::class);
+		$eventDispatcher = $this->getContainer()->get(IEventDispatcher::class);
 		$eventDispatcher->addListener(
-		    BeforePreviewFetchedEvent::class,
+			BeforePreviewFetchedEvent::class,
 			function (BeforePreviewFetchedEvent $event) {
 				$this->listenPreviewFile($event);
 			}
@@ -60,7 +60,7 @@ class Application extends App implements IBootstrap {
 	 */
 	public function listenReadFile(array $params): void {
 		/** @var Listener $hooks */
-		$hooks = $this->getContainer()->query(Listener::class);
+		$hooks = $this->getContainer()->get(Listener::class);
 		$hooks->readFile($params['path']);
 	}
 
@@ -88,7 +88,7 @@ class Application extends App implements IBootstrap {
 		}
 
 		/** @var Listener $hooks */
-		$hooks = $this->getContainer()->query(Listener::class);
+		$hooks = $this->getContainer()->get(Listener::class);
 		$hooks->readFile($path);
 	}
 }


### PR DESCRIPTION
Upgrade of the app to the new event API to make it work with Nextcloud 28.

https://help.nextcloud.com/t/symfony-event-dispatcher-update-in-nextcloud-server-28-breaking-changes/167550