### PR TITLE
Update Application.php

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCP\Files\File;
 use OCP\IPreview;
 use OCP\Util;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'files_downloadactivity';
@@ -46,9 +47,9 @@ class Application extends App implements IBootstrap {
 	public function boot(IBootContext $context): void {
 		Util::connectHook('OC_Filesystem', 'read', $this, 'listenReadFile');
 
-		$eventDispatcher = $context->getServerContainer()->getEventDispatcher();
+		$eventDispatcher = $this->getContainer()->query(IEventDispatcher::class);
 		$eventDispatcher->addListener(
-			IPreview::EVENT,
+			AddEvent::class,
 			function (GenericEvent $event) {
 				$this->listenPreviewFile($event);
 			}


### PR DESCRIPTION
Should help make the app compatible to nextcloud 28...

Old: 
$eventDispatcher = $context->getServerContainer()->getEventDispatcher();

New:
$eventDispatcher = $this->getContainer()->query(IEventDispatcher::class);

And addListener updated.
See: https://docs.nextcloud.com/server/stable/developer_manual/basics/events.html

Seems to work. Please correct, if I am wrong.